### PR TITLE
Add order service with models and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Orders Service Example
+
+This repository contains a simple example of handling service orders. It demonstrates how to create service orders, generate receipt protocols, and prepare invoice information.
+
+## Running the Application
+
+The project is purely demonstrational and does not include a CLI. To interact with the services, import the modules in a Python interpreter:
+
+```bash
+python -i -m src.orders.services
+```
+
+Or use them programmatically in your own code.
+
+## Running Tests
+
+The project uses the built‑in `unittest` framework. Run the tests with:
+
+```bash
+python -m unittest discover tests
+```

--- a/src/orders/models.py
+++ b/src/orders/models.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+@dataclass
+class ServiceOrder:
+    order_id: int
+    customer_name: str
+    service_description: str
+    price: float
+
+@dataclass
+class ReceiptProtocol:
+    protocol_id: int
+    order: ServiceOrder
+    issued_at: datetime
+
+@dataclass
+class InvoiceInfo:
+    invoice_id: int
+    protocol: ReceiptProtocol
+    total: float

--- a/src/orders/services.py
+++ b/src/orders/services.py
@@ -1,0 +1,43 @@
+"""Services for handling orders and invoices."""
+
+from datetime import datetime
+from typing import Optional
+from .models import ServiceOrder, ReceiptProtocol, InvoiceInfo
+
+
+_next_protocol_id = 1
+_next_invoice_id = 1
+
+
+def create_service_order(order_id: int, customer_name: str, service_description: str, price: float) -> ServiceOrder:
+    """Create a new ServiceOrder instance."""
+    return ServiceOrder(
+        order_id=order_id,
+        customer_name=customer_name,
+        service_description=service_description,
+        price=price,
+    )
+
+
+def generate_receipt_protocol(order: ServiceOrder) -> ReceiptProtocol:
+    """Generate a receipt protocol for the given service order."""
+    global _next_protocol_id
+    protocol = ReceiptProtocol(
+        protocol_id=_next_protocol_id,
+        order=order,
+        issued_at=datetime.utcnow(),
+    )
+    _next_protocol_id += 1
+    return protocol
+
+
+def prepare_invoice_info(protocol: ReceiptProtocol) -> InvoiceInfo:
+    """Prepare invoice information based on the receipt protocol."""
+    global _next_invoice_id
+    invoice = InvoiceInfo(
+        invoice_id=_next_invoice_id,
+        protocol=protocol,
+        total=protocol.order.price,
+    )
+    _next_invoice_id += 1
+    return invoice

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,0 +1,37 @@
+import unittest
+from datetime import datetime
+
+from src.orders.models import ServiceOrder, ReceiptProtocol, InvoiceInfo
+from src.orders import services
+
+
+class ServiceTests(unittest.TestCase):
+    def test_create_service_order(self):
+        order = services.create_service_order(
+            order_id=1,
+            customer_name="John Doe",
+            service_description="Cleaning",
+            price=100.0,
+        )
+        self.assertEqual(order.order_id, 1)
+        self.assertEqual(order.customer_name, "John Doe")
+        self.assertEqual(order.price, 100.0)
+
+    def test_generate_receipt_protocol(self):
+        order = services.create_service_order(1, "John", "Test", 50.0)
+        protocol = services.generate_receipt_protocol(order)
+        self.assertIsInstance(protocol, ReceiptProtocol)
+        self.assertEqual(protocol.order, order)
+        self.assertIsInstance(protocol.issued_at, datetime)
+
+    def test_prepare_invoice_info(self):
+        order = services.create_service_order(1, "John", "Test", 50.0)
+        protocol = services.generate_receipt_protocol(order)
+        invoice = services.prepare_invoice_info(protocol)
+        self.assertIsInstance(invoice, InvoiceInfo)
+        self.assertEqual(invoice.protocol, protocol)
+        self.assertEqual(invoice.total, 50.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- set up orders package with dataclass models
- add services to create orders, protocols and invoices
- provide unit tests for the service module
- document how to run the example and tests

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_684000c8ab8483339ead3076c1fe4a2e